### PR TITLE
Prevent funds from being stolen via the PM being set twice

### DIFF
--- a/packages/hardhat/contracts/ToKanBan.sol
+++ b/packages/hardhat/contracts/ToKanBan.sol
@@ -44,6 +44,7 @@ contract ToKanBan{
 
     //setting the PM
     function setPM(address _pm) public {
+        require(pm == address(0), "The PM has already been set");
         pm = _pm;
     }
 

--- a/packages/hardhat/test/tokanban-test.js
+++ b/packages/hardhat/test/tokanban-test.js
@@ -62,6 +62,12 @@ describe("ToKanBan", function () {
       await this.kanban.setPM(this.accounts[0].address);
     })
 
+    then("the PM can't be set again", async function () {
+      await expect(
+        this.kanban.setPM(this.accounts[0].address)
+      ).to.be.rejectedWith("The PM has already been set");
+    });
+
     then("tasks can be submitted", async function () {
       const value = ethers.utils.parseEther("1");
       const details = "A sample task";


### PR DESCRIPTION
Before this commit, anyone could set themselves as the PM and steal funds.